### PR TITLE
Integrate hCaptcha verification and validation

### DIFF
--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -31,7 +31,7 @@ export async function POST(request) {
 
         // Validate input with Zod
         const validationResult = contactSchema.safeParse(body);
-        
+
         if (!validationResult.success) {
             return NextResponse.json(
                 { error: 'Validation failed', details: validationResult.error.errors },
@@ -42,12 +42,17 @@ export async function POST(request) {
         const { name, email, subject, message, captchaToken } = validationResult.data;
 
         // Verify hCaptcha token
+        const captchaPayload = new URLSearchParams({
+            response: captchaToken,
+            secret: process.env.HCAPTCHA_SECRET_KEY || '',
+        });
+
         const captchaResponse = await fetch('https://hcaptcha.com/siteverify', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            body: `response=${captchaToken}&secret=${process.env.HCAPTCHA_SECRET_KEY}`,
+            body: captchaPayload.toString(),
         });
 
         if (!captchaResponse.ok) {
@@ -98,7 +103,7 @@ export async function POST(request) {
         if (process.env.NODE_ENV === 'development') {
             console.error('Contact form error:', error);
         }
-        
+
         return NextResponse.json(
             { error: 'Failed to send message. Please try again.' },
             { status: 500 }

--- a/components/contact-form.jsx
+++ b/components/contact-form.jsx
@@ -12,6 +12,7 @@ const formSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
   subject: z.string().min(5, "Subject must be at least 5 characters").max(200),
   message: z.string().min(10, "Message must be at least 10 characters").max(5000),
+  captchaToken: z.string().min(1, "Please complete the captcha"),
 });
 
 export default function ContactForm() {
@@ -30,13 +31,18 @@ export default function ContactForm() {
       email: "",
       subject: "",
       message: "",
+      captchaToken: "",
     },
   });
 
   const captchaToken = watch("captchaToken");
 
   const handleCaptchaVerify = (token) => {
-    setValue("captchaToken", token);
+    setValue("captchaToken", token, { shouldValidate: true });
+  };
+
+  const handleCaptchaExpire = () => {
+    setValue("captchaToken", "", { shouldValidate: true });
   };
 
   const onSubmit = async (data) => {
@@ -178,13 +184,19 @@ export default function ContactForm() {
       </div>
 
       <div className="flex justify-center">
+        <input type="hidden" {...register("captchaToken")} />
         <HCaptcha
           ref={captchaRef}
           sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY}
           onVerify={handleCaptchaVerify}
+          onExpire={handleCaptchaExpire}
+          onError={handleCaptchaExpire}
           theme="dark"
         />
       </div>
+      {errors.captchaToken && (
+        <p className="text-center text-xs text-destructive">{errors.captchaToken.message}</p>
+      )}
 
       <button
         type="submit"


### PR DESCRIPTION
Add client and server handling for hCaptcha on the contact form: include captchaToken in the form Zod schema and default values, register a hidden input, validate and react to token verify/expire/error (setValue with shouldValidate), and display captcha errors. On the server, send the hCaptcha verification request using URLSearchParams (response + secret) to hcaptcha.com/siteverify. Also remove minor extraneous whitespace.