### PR TITLE
Add llms, JSON-LD, sitemap, robots APIs

### DIFF
--- a/app/api/agent/route.js
+++ b/app/api/agent/route.js
@@ -1,0 +1,57 @@
+export const runtime = "edge";
+
+const payload = {
+  schema: "https://schema.org/Person",
+  name: "Hector Mendoza",
+  jobTitle: "Head of Web Integrations",
+  description:
+    "Senior Software Engineer & Lead Developer with 8+ years of experience crafting performant, accessible web experiences. Based in Morelia, Mexico.",
+  url: "https://hectormendoza.com",
+  email: "hey@hectormendoza.me",
+  location: {
+    city: "Morelia",
+    country: "Mexico",
+    timezone: "UTC-6",
+    coordinates: "19.70° N, 101.19° W",
+  },
+  availability: "Open to new projects and collaborations",
+  skills: {
+    frontend: ["React", "Next.js", "TypeScript", "Tailwind CSS", "Three.js", "GSAP"],
+    cms: ["WordPress", "WooCommerce", "Shopify", "Headless CMS"],
+    design: ["Figma", "Responsive Design", "Pixel-Perfect"],
+    backend: ["Node.js", "Firebase", "APIs", "Pipedream"],
+  },
+  experience: [
+    { role: "Head of Web Integrations", company: "UrVenue", period: "2024–Present", location: "Morelia, Mexico" },
+    { role: "Web Services Developer", company: "UrVenue", period: "2023–2024", location: "Morelia, Mexico" },
+    { role: "Office Manager & Lead Developer", company: "Once Interactive Inc.", period: "2019–2023", location: "Remote" },
+    { role: "Senior Web Developer", company: "Once Interactive Inc.", period: "2017–2023", location: "Remote" },
+    { role: "Web Developer", company: "COPARMEX Michoacán", period: "2017", location: "Morelia, Mexico" },
+  ],
+  education: [
+    { degree: "Master's in Computer Science", specialty: "Mobile App Development", school: "Universidad Vasco de Quiroga", period: "2018–2020" },
+    { degree: "Engineer's in Computer Science", school: "Universidad Vasco de Quiroga", period: "2013–2017" },
+  ],
+  projects: [
+    { title: "Cantera Diez Hotel", url: "https://canteradiezhotel.com", stack: ["AngularJS", "Firebase", "i18n"], category: "Hospitality", year: 2025 },
+    { title: "Vibe Theme", url: "https://vibetheme.hectormendoza.me", stack: ["Design", "VS Code", "Color Theory"], category: "Design Tool", year: 2026 },
+    { title: "Astes", url: "https://astes.com.mx", stack: ["WordPress", "SEO"], category: "Corporate", year: 2024 },
+    { title: "Mojito Cocktails", url: "https://gsap-cocktails-hm.vercel.app", stack: ["GSAP", "Next.js", "WebGL"], category: "Creative Dev", year: 2026 },
+    { title: "Our Wedding", url: "http://wedding.hectormendoza.me", stack: ["Next.js", "Tailwind CSS"], category: "Personal", year: 2025 },
+  ],
+  social: {
+    github: "https://github.com/hector-mendoza",
+    linkedin: "https://www.linkedin.com/in/hector-mendoza-m/",
+    threads: "https://www.threads.com/@hectormendozax2",
+  },
+  llmsTxt: "https://hectormendoza.com/llms.txt",
+};
+
+export function GET() {
+  return Response.json(payload, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/app/api/crawl-rules/route.js
+++ b/app/api/crawl-rules/route.js
@@ -1,0 +1,58 @@
+export const runtime = "edge";
+
+const ROBOTS_TXT = `User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: https://hectormendoza.com/sitemap.xml
+Host: https://hectormendoza.com
+`;
+
+export function GET() {
+  return new Response(ROBOTS_TXT, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/app/api/page-markdown/route.js
+++ b/app/api/page-markdown/route.js
@@ -1,0 +1,13 @@
+export const runtime = "edge";
+
+export async function GET(request) {
+  const origin = new URL(request.url).origin;
+  const res = await fetch(`${origin}/llms.txt`);
+  const text = await res.text();
+  return new Response(text, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -54,9 +54,33 @@ export const viewport = {
   initialScale: 1,
 };
 
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Hector Mendoza",
+  jobTitle: "Head of Web Integrations",
+  description: "Senior Software Engineer & Lead Developer with 8+ years of experience. Based in Morelia, Mexico.",
+  url: "https://hectormendoza.com",
+  email: "hey@hectormendoza.me",
+  sameAs: [
+    "https://github.com/hector-mendoza",
+    "https://www.linkedin.com/in/hector-mendoza-m/",
+    "https://www.threads.com/@hectormendozax2",
+  ],
+  address: { "@type": "PostalAddress", addressLocality: "Morelia", addressCountry: "MX" },
+  knowsAbout: ["React", "Next.js", "TypeScript", "WordPress", "Shopify", "Node.js", "Tailwind CSS", "Figma"],
+  worksFor: { "@type": "Organization", name: "UrVenue" },
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body
         className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} font-sans antialiased`}
       >

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,11 @@
+export default function sitemap() {
+  const base = "https://hectormendoza.com";
+  return [
+    {
+      url: base,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export function middleware(request) {
+  const accept = request.headers.get("accept") ?? "";
+  if (accept.includes("text/markdown")) {
+    return NextResponse.rewrite(new URL("/api/page-markdown", request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/",
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,33 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-}
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/robots.txt",
+          destination: "/api/crawl-rules",
+        },
+      ],
+    };
+  },
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: [
+              '</api/agent>; rel="service-desc"',
+              '</llms.txt>; rel="service-doc"',
+              '</sitemap.xml>; rel="sitemap"',
+            ].join(", "),
+          },
+        ],
+      },
+    ];
+  },
+};
 
-export default nextConfig
+export default nextConfig;

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,48 @@
+# Hector Mendoza
+
+> Senior Software Engineer & Lead Developer based in Morelia, Mexico. Head of Web Integrations at UrVenue. 8+ years crafting performant, accessible, and visually polished web experiences.
+
+## About
+
+Hector Mendoza is a Senior Web Developer and Lead Developer with 8+ years of experience. Currently serving as Head of Web Integrations at UrVenue, where he leads web integrations strategy and execution for enterprise venue technology clients. Previously Lead Developer and Office Manager at Once Interactive Inc., collaborating with 50+ international companies across e-commerce, hospitality, and corporate sectors. Holds a Master's degree in Computer Science (Mobile App Development) from Universidad Vasco de Quiroga.
+
+## Experience
+
+- Head of Web Integrations — UrVenue (2024–Present), Morelia, Mexico
+- Web Services Developer — UrVenue (2023–2024), Morelia, Mexico
+- Office Manager & Lead Developer — Once Interactive Inc. (2019–2023), Remote
+- Senior Web Developer — Once Interactive Inc. (2017–2023), Remote
+- Web Developer — COPARMEX Michoacán (2017), Morelia, Mexico
+
+## Skills
+
+- **Frontend:** React, Next.js, TypeScript, Tailwind CSS, Three.js, GSAP
+- **CMS & E-Commerce:** WordPress, WooCommerce, Shopify, Headless CMS
+- **Design & UX:** Figma, Responsive Design, Pixel-Perfect implementation
+- **Backend & Integrations:** Node.js, Firebase, APIs, Pipedream, SEO
+
+## Projects
+
+- [Cantera Diez Hotel](https://canteradiezhotel.com) — Hotel & Hospitality website built with AngularJS & Firebase, featuring i18n bilingual support and room showcasing (2025)
+- [Vibe Theme](https://vibetheme.hectormendoza.me) — VS Code & Cursor theme collection, 8 premium dark themes, MIT licensed, free forever (2026)
+- [Astes](https://astes.com.mx) — Corporate website built with WordPress, SEO-optimized (2024)
+- [Mojito Cocktails](https://gsap-cocktails-hm.vercel.app) — GSAP animation showcase with scroll-driven animations and 3D transforms (2026)
+- [Our Wedding](http://wedding.hectormendoza.me) — Personal wedding website with RSVP management and countdown timer (2025)
+
+## Education
+
+- Master's Degree in Computer Science, Specialty in Mobile App Development — Universidad Vasco de Quiroga (2018–2020)
+- Engineer's Degree in Computer Science — Universidad Vasco de Quiroga (2013–2017)
+
+## Contact
+
+- Email: hey@hectormendoza.me
+- Location: Morelia, Mexico (UTC−6, 19.70° N · 101.19° W)
+- Website: https://hectormendoza.com
+- GitHub: https://github.com/hector-mendoza
+- LinkedIn: https://www.linkedin.com/in/hector-mendoza-m/
+- Threads: https://www.threads.com/@hectormendozax2
+
+## Availability
+
+Open to new projects and collaborations. Specializes in performant, accessible web experiences for hospitality, e-commerce, and corporate clients.


### PR DESCRIPTION
Introduce AI/agent metadata and crawl rules: add public/llms.txt and API endpoints (app/api/agent, app/api/crawl-rules, app/api/page-markdown) to serve profile JSON, robots.txt content, and markdown view. Add middleware to rewrite requests for text/markdown to the page-markdown endpoint. Add app/sitemap.js and embed JSON-LD Person metadata in app/layout.jsx. Update next.config.mjs with a rewrite for /robots.txt and Link headers (service-desc, service-doc, sitemap); responses include cache headers.